### PR TITLE
fix broken links in /tools

### DIFF
--- a/src/tools.md
+++ b/src/tools.md
@@ -8,8 +8,6 @@ type: activemq5
 [Tools](tools)
 
 
-*   [Hermes Jms](ToolsTools/Tools/hermes-Community/FAQ/jms)
-*   [Hermes Screenshot](hermes-screenshot)
 *   [Java Service Wrapper](java-service-wrapper)
 *   [Maven2 ActiveMQ Broker Plugin](maven2-activemq-broker-plugin)
 *   [Web Console](web-console)

--- a/src/tools.md
+++ b/src/tools.md
@@ -8,8 +8,7 @@ type: activemq5
 [Tools](tools)
 
 
-*   [Hermes Jms](ToolsTools/Tools/hermes-Community/FAQ/jms)
-*   [Hermes Screenshot](hermes-screenshot)
+*   [Hermes Jms](hermes-jms)
 *   [Java Service Wrapper](java-service-wrapper)
 *   [Maven2 ActiveMQ Broker Plugin](maven2-activemq-broker-plugin)
 *   [Web Console](web-console)


### PR DESCRIPTION
Fix broken links in https://activemq.apache.org/tools
- Hermes Jms
- Hermes Screenshot

Changes: 
- remove "Hermes Screenshot" from /tools page
- replace "Hermes Jms" link from https://activemq.apache.org/ToolsTools/Tools/hermes-Community/FAQ/jms to https://activemq.apache.org/hermes-jms

 
